### PR TITLE
Add "Raw Mode" to Tech Icon

### DIFF
--- a/projects/angular-techs-logos/src/lib/angular-techs-logos.component.html
+++ b/projects/angular-techs-logos/src/lib/angular-techs-logos.component.html
@@ -1,28 +1,38 @@
-<div class="techs" [ngClass]="class">
+@if(raw) {
   @if (name && getTech(name) && !list) {
-    <figure
-      class="tech-container"
-      [ngClass]="techClass(name)"
-      [style.width]="size ? size : '100px'"
-    >
-      <ng-container *ngComponentOutlet="getIcon(name)" />
-      <figcaption [ngClass]="{ tooltip: hiddenLabel }">
-        {{ label ? label : getTech(name)?.name }}
-      </figcaption>
-    </figure>
+    <ng-container *ngComponentOutlet="getIcon(name)" />
   } @else if (!name && (list || hiddenLogos || techsList())) {
     @for (tech of techsList(); track tech.name;) {
-      <figure
-        class="tech-container"
-        [ngClass]="[tech.name.toLowerCase()]"
-        [style.width]="size ? size : '100px'"
-        [attr.key]="tech.name"
-      >
-        <ng-container *ngComponentOutlet="getIcon(tech.name)" />
-        <figcaption [ngClass]="{ tooltip: hiddenLabel }">
-          {{ tech.name }}
-        </figcaption>
-      </figure>
+      <ng-container *ngComponentOutlet="getIcon(tech.name)" />
     }
   }
-</div>
+} @else {
+  <div class="techs" [ngClass]="class">
+    @if (name && getTech(name) && !list) {
+      <figure
+        class="tech-container"
+        [ngClass]="techClass(name)"
+        [style.width]="size ? size : '100px'"
+      >
+        <ng-container *ngComponentOutlet="getIcon(name)" />
+        <figcaption [ngClass]="{ tooltip: hiddenLabel }">
+          {{ label ? label : getTech(name)?.name }}
+        </figcaption>
+      </figure>
+    } @else if (!name && (list || hiddenLogos || techsList())) {
+      @for (tech of techsList(); track tech.name;) {
+        <figure
+          class="tech-container"
+          [ngClass]="[tech.name.toLowerCase()]"
+          [style.width]="size ? size : '100px'"
+          [attr.key]="tech.name"
+        >
+          <ng-container *ngComponentOutlet="getIcon(tech.name)" />
+          <figcaption [ngClass]="{ tooltip: hiddenLabel }">
+            {{ tech.name }}
+          </figcaption>
+        </figure>
+      }
+    }
+  </div>
+}

--- a/projects/angular-techs-logos/src/lib/angular-techs-logos.component.scss
+++ b/projects/angular-techs-logos/src/lib/angular-techs-logos.component.scss
@@ -27,9 +27,15 @@ figure.tech-container {
     border-color: var(--vtl-background);
     transform: scale(1.1);
   }
+}
+
+.tech-icon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   svg {
+    width: 70px;
     height: 50px;
-    margin-bottom: .2rem;
   }
 }
 
@@ -39,6 +45,7 @@ figure {
   margin: .2rem;
   figcaption {
     font-size: .7rem;
+    margin-top: .2rem;
     &.tooltip {
       position: absolute;
       bottom: 2%;

--- a/projects/angular-techs-logos/src/lib/angular-techs-logos.component.ts
+++ b/projects/angular-techs-logos/src/lib/angular-techs-logos.component.ts
@@ -25,6 +25,7 @@ export class AngularTechsLogosComponent implements OnInit, OnChanges {
   @Input() size: string | undefined;
   @Input() label: string | undefined;
   @Input() hiddenLabel: boolean | undefined;
+  @Input() raw: boolean | undefined;
   @Input() class: string | undefined;
   @Input() hiddenLogos: string[] | undefined;
 

--- a/projects/angular-techs-logos/src/lib/techs/amd/amd.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/amd/amd.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-amd',
+  selector: 'i.tech-icon.logo-amd',
   templateUrl: './amd.component.svg'
 })
 export class AmdComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/android/android.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/android/android.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-android',
+  selector: 'i.tech-icon.logo-android',
   templateUrl: './android.component.svg'
 })
 export class AndroidComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/androidstudio/androidstudio.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/androidstudio/androidstudio.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-androidstudio',
+  selector: 'i.tech-icon.logo-androidstudio',
   templateUrl: './androidstudio.component.svg'
 })
 export class AndroidstudioComponent { }

--- a/projects/angular-techs-logos/src/lib/techs/angular/angular.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/angular/angular.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-angular',
+  selector: 'i.tech-icon.logo-angular',
   templateUrl: './angular.component.svg'
 })
 export class AngularComponent { }

--- a/projects/angular-techs-logos/src/lib/techs/ansible/ansible.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/ansible/ansible.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-ansible',
+  selector: 'i.tech-icon.logo-ansible',
   templateUrl: './ansible.component.svg'
 })
 export class AnsibleComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/apache/apache.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/apache/apache.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-apache',
+  selector: 'i.tech-icon.logo-apache',
   templateUrl: './apache.component.svg'
 })
 export class ApacheComponent { }

--- a/projects/angular-techs-logos/src/lib/techs/apple/apple.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/apple/apple.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-apple',
+  selector: 'i.tech-icon.logo-apple',
   templateUrl: './apple.component.svg'
 })
 export class AppleComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/appstore/appstore.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/appstore/appstore.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-appstore',
+  selector: 'i.tech-icon.logo-appstore',
   templateUrl: './appstore.component.svg'
 })
 export class AppStoreComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/archlinux/archlinux.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/archlinux/archlinux.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-archlinux',
+  selector: 'i.tech-icon.logo-archlinux',
   templateUrl: './archlinux.component.svg'
 })
 export class ArchlinuxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/astro/astro.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/astro/astro.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-astro',
+  selector: 'i.tech-icon.logo-astro',
   templateUrl: './astro.component.svg'
 })
 export class AstroComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/aws/aws.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/aws/aws.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  selector: 'logo-aws',
+  selector: 'i.tech-icon.logo-aws',
   templateUrl: './aws.component.svg',
   styleUrls: ['./aws.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/angular-techs-logos/src/lib/techs/azure/azure.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/azure/azure.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-azure',
+  selector: 'i.tech-icon.logo-azure',
   templateUrl: './azure.component.svg'
 })
 export class AzureComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/backbone/backbone.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/backbone/backbone.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-backbone',
+  selector: 'i.tech-icon.logo-backbone',
   templateUrl: './backbone.component.svg'
 })
 export class BackboneComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/baidu/baidu.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/baidu/baidu.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-baidu',
+  selector: 'i.tech-icon.logo-baidu',
   templateUrl: './baidu.component.svg'
 })
 export class BaiduComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/bitbucket/bitbucket.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/bitbucket/bitbucket.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-bitbucket',
+  selector: 'i.tech-icon.logo-bitbucket',
   templateUrl: './bitbucket.component.svg'
 })
 export class BitbucketComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/centos/centos.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/centos/centos.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-centos',
+  selector: 'i.tech-icon.logo-centos',
   templateUrl: './centos.component.svg'
 })
 export class CentosComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/chatgpt/chatgpt.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/chatgpt/chatgpt.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-chatgpt',
+  selector: 'i.tech-icon.logo-chatgpt',
   templateUrl: './chatgpt.component.svg'
 })
 export class ChatgptComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/chrome/chrome.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/chrome/chrome.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-chrome',
+  selector: 'i.tech-icon.logo-chrome',
   templateUrl: './chrome.component.svg'
 })
 export class ChromeComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/circleci/circleci.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/circleci/circleci.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-circleci',
+  selector: 'i.tech-icon.logo-circleci',
   templateUrl: './circleci.component.svg'
 })
 export class CircleCiComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/cisco/cisco.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/cisco/cisco.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-cisco',
+  selector: 'i.tech-icon.logo-cisco',
   templateUrl: './cisco.component.svg'
 })
 export class CiscoComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/cobol/cobol.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/cobol/cobol.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-cobol',
+  selector: 'i.tech-icon.logo-cobol',
   templateUrl: './cobol.component.svg'
 })
 export class CobolComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/codepen/codepen.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/codepen/codepen.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-codepen',
+  selector: 'i.tech-icon.logo-codepen',
   templateUrl: './codepen.component.svg'
 })
 export class CodepenComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/copilot/copilot.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/copilot/copilot.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-copilot',
+  selector: 'i.tech-icon.logo-copilot',
   templateUrl: './copilot.component.svg'
 })
 export class CopilotComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/cpp/cpp.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/cpp/cpp.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-cpp',
+  selector: 'i.tech-icon.logo-cpp',
   templateUrl: './cpp.component.svg'
 })
 export class CppComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/csharp/csharp.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/csharp/csharp.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-csharp',
+  selector: 'i.tech-icon.logo-csharp',
   templateUrl: './csharp.component.svg'
 })
 export class CsharpComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/css/css.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/css/css.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-css',
+  selector: 'i.tech-icon.logo-css',
   templateUrl: './css.component.svg'
 })
 export class CssComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/cypress/cypress.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/cypress/cypress.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-cypress',
+  selector: 'i.tech-icon.logo-cypress',
   templateUrl: './cypress.component.svg'
 })
 export class CypressComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/d3/d3.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/d3/d3.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-d3',
+  selector: 'i.tech-icon.logo-d3',
   templateUrl: './d3.component.svg'
 })
 export class D3Component {}

--- a/projects/angular-techs-logos/src/lib/techs/debian/debian.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/debian/debian.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-debian',
+  selector: 'i.tech-icon.logo-debian',
   templateUrl: './debian.component.svg'
 })
 export class DebianComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/deepin/deepin.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/deepin/deepin.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-deepin',
+  selector: 'i.tech-icon.logo-deepin',
   templateUrl: './deepin.component.svg'
 })
 export class DeepinComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/deezer/deezer.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/deezer/deezer.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-deezer',
+  selector: 'i.tech-icon.logo-deezer',
   templateUrl: './deezer.component.svg'
 })
 export class DeezerComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/digitalocean/digitalocean.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/digitalocean/digitalocean.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-digitalocean',
+  selector: 'i.tech-icon.logo-digitalocean',
   templateUrl: './digitalocean.component.svg'
 })
 export class DigitaloceanComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/discord/discord.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/discord/discord.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-discord',
+  selector: 'i.tech-icon.logo-discord',
   templateUrl: './discord.component.svg'
 })
 export class DiscordComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/docker/docker.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/docker/docker.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-docker',
+  selector: 'i.tech-icon.logo-docker',
   templateUrl: './docker.component.svg'
 })
 export class DockerComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/dribbble/dribbble.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/dribbble/dribbble.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-dribbble',
+  selector: 'i.tech-icon.logo-dribbble',
   templateUrl: './dribbble.component.svg'
 })
 export class DribbbleComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/dropbox/dropbox.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/dropbox/dropbox.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-dropbox',
+  selector: 'i.tech-icon.logo-dropbox',
   templateUrl: './dropbox.component.svg'
 })
 export class DropboxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/drupal/drupal.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/drupal/drupal.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-drupal',
+  selector: 'i.tech-icon.logo-drupal',
   templateUrl: './drupal.component.svg'
 })
 export class DrupalComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/duckduckgo/duckduckgo.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/duckduckgo/duckduckgo.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-duckduckgo',
+  selector: 'i.tech-icon.logo-duckduckgo',
   templateUrl: './duckduckgo.component.svg'
 })
 export class DuckduckgoComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/eclipse/eclipse.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/eclipse/eclipse.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  selector: 'logo-eclipse',
+  selector: 'i.tech-icon.logo-eclipse',
   templateUrl: './eclipse.component.svg',
   styleUrls: ['./eclipse.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/angular-techs-logos/src/lib/techs/edge/edge.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/edge/edge.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-edge',
+  selector: 'i.tech-icon.logo-edge',
   templateUrl: './edge.component.svg'
 })
 export class EdgeComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/elementaryos/elementaryos.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/elementaryos/elementaryos.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-elementaryos',
+  selector: 'i.tech-icon.logo-elementaryos',
   templateUrl: './elementaryos.component.svg',
   styleUrls: ['./elementaryos.component.scss']
 })

--- a/projects/angular-techs-logos/src/lib/techs/elo/elo.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/elo/elo.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-elo',
+  selector: 'i.tech-icon.logo-elo',
   templateUrl: './elo.component.svg'
 })
 export class EloComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/ember/ember.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/ember/ember.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-ember',
+  selector: 'i.tech-icon.logo-ember',
   templateUrl: './ember.component.svg'
 })
 export class EmberComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/evernote/evernote.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/evernote/evernote.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-evernote',
+  selector: 'i.tech-icon.logo-evernote',
   templateUrl: './evernote.component.svg'
 })
 export class EvernoteComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/expo/expo.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/expo/expo.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-expo',
+  selector: 'i.tech-icon.logo-expo',
   templateUrl: './expo.component.svg'
 })
 export class ExpoComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/facebook/facebook.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/facebook/facebook.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-facebook',
+  selector: 'i.tech-icon.logo-facebook',
   templateUrl: './facebook.component.svg'
 })
 export class FacebookComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/fedora/fedora.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/fedora/fedora.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-fedora',
+  selector: 'i.tech-icon.logo-fedora',
   templateUrl: './fedora.component.svg'
 })
 export class FedoraComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/firebase/firebase.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/firebase/firebase.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-firebase',
+  selector: 'i.tech-icon.logo-firebase',
   templateUrl: './firebase.component.svg'
 })
 export class FirebaseComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/firefox/firefox.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/firefox/firefox.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-firefox',
+  selector: 'i.tech-icon.logo-firefox',
   templateUrl: './firefox.component.svg'
 })
 export class FirefoxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/fortran/fortran.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/fortran/fortran.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-fortran',
+  selector: 'i.tech-icon.logo-fortran',
   templateUrl: './fortran.component.svg'
 })
 export class FortranComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/gemini/gemini.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/gemini/gemini.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-gemini',
+  selector: 'i.tech-icon.logo-gemini',
   templateUrl: './gemini.component.svg'
 })
 export class GeminiComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/git/git.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/git/git.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-git',
+  selector: 'i.tech-icon.logo-git',
   templateUrl: './git.component.svg'
 })
 export class GitComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/github/github.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/github/github.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-github',
+  selector: 'i.tech-icon.logo-github',
   templateUrl: './github.component.svg'
 })
 export class GithubComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/gitlab/gitlab.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/gitlab/gitlab.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-gitlab',
+  selector: 'i.tech-icon.logo-gitlab',
   templateUrl: './gitlab.component.svg'
 })
 export class GitlabComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/go/go.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/go/go.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-go',
+  selector: 'i.tech-icon.logo-go',
   templateUrl: './go.component.svg'
 })
 export class GoComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/google/google.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/google/google.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-google',
+  selector: 'i.tech-icon.logo-google',
   templateUrl: './google.component.svg'
 })
 export class GoogleComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/grafana/grafana.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/grafana/grafana.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-grafana',
+  selector: 'i.tech-icon.logo-grafana',
   templateUrl: './grafana.component.svg'
 })
 export class GrafanaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/graylog/graylog.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/graylog/graylog.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-graylog',
+  selector: 'i.tech-icon.logo-graylog',
   templateUrl: './graylog.component.svg'
 })
 export class GraylogComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/gulp/gulp.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/gulp/gulp.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-gulp',
+  selector: 'i.tech-icon.logo-gulp',
   templateUrl: './gulp.component.svg'
 })
 export class GulpComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/hp/hp.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/hp/hp.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-hp',
+  selector: 'i.tech-icon.logo-hp',
   templateUrl: './hp.component.svg'
 })
 export class HpComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/html/html.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/html/html.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-html',
+  selector: 'i.tech-icon.logo-html',
   templateUrl: './html.component.svg'
 })
 export class HtmlComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/ibm/ibm.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/ibm/ibm.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-ibm',
+  selector: 'i.tech-icon.logo-ibm',
   templateUrl: './ibm.component.svg'
 })
 export class IbmComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/instagram/instagram.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/instagram/instagram.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-instagram',
+  selector: 'i.tech-icon.logo-instagram',
   templateUrl: './instagram.component.svg'
 })
 export class InstagramComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/intellij/intellij.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/intellij/intellij.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-intellij',
+  selector: 'i.tech-icon.logo-intellij',
   templateUrl: './intellij.component.svg'
 })
 export class IntellijComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/java/java.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/java/java.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-java',
+  selector: 'i.tech-icon.logo-java',
   templateUrl: './java.component.svg'
 })
 export class JavaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/javascript/javascript.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/javascript/javascript.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-javascript',
+  selector: 'i.tech-icon.logo-javascript',
   templateUrl: './javascript.component.svg'
 })
 export class JavascriptComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/jest/jest.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/jest/jest.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-jest',
+  selector: 'i.tech-icon.logo-jest',
   templateUrl: './jest.component.svg'
 })
 export class JestComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/jetbrains/jetbrains.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/jetbrains/jetbrains.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-jetbrains',
+  selector: 'i.tech-icon.logo-jetbrains',
   templateUrl: './jetbrains.component.svg'
 })
 export class JetbrainsComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/kalilinux/kalilinux.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/kalilinux/kalilinux.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-kalilinux',
+  selector: 'i.tech-icon.logo-kalilinux',
   templateUrl: './kalilinux.component.svg'
 })
 export class KalilinuxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/karma/karma.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/karma/karma.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-karma',
+  selector: 'i.tech-icon.logo-karma',
   templateUrl: './karma.component.svg'
 })
 export class KarmaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/kotlin/kotlin.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/kotlin/kotlin.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-kotlin',
+  selector: 'i.tech-icon.logo-kotlin',
   templateUrl: './kotlin.component.svg'
 })
 export class KotlinComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/kubernets/kubernets.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/kubernets/kubernets.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-kubernets',
+  selector: 'i.tech-icon.logo-kubernets',
   templateUrl: './kubernets.component.svg'
 })
 export class KubernetsComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/less/less.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/less/less.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-less',
+  selector: 'i.tech-icon.logo-less',
   templateUrl: './less.component.svg'
 })
 export class LessComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/linkedin/linkedin.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/linkedin/linkedin.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-linkedin',
+  selector: 'i.tech-icon.logo-linkedin',
   templateUrl: './linkedin.component.svg'
 })
 export class LinkedinComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/linux/linux.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/linux/linux.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-linux',
+  selector: 'i.tech-icon.logo-linux',
   templateUrl: './linux.component.svg'
 })
 export class LinuxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/lua/lua.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/lua/lua.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-lua',
+  selector: 'i.tech-icon.logo-lua',
   templateUrl: './lua.component.svg'
 })
 export class LuaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/macos/macos.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/macos/macos.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  selector: 'logo-macos',
+  selector: 'i.tech-icon.logo-macos',
   templateUrl: './macos.component.svg',
   styleUrls: ['./macos.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/angular-techs-logos/src/lib/techs/manjaro/manjaro.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/manjaro/manjaro.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-manjaro',
+  selector: 'i.tech-icon.logo-manjaro',
   templateUrl: './manjaro.component.svg'
 })
 export class ManjaroComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/mariadb/mariadb.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/mariadb/mariadb.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-mariadb',
+  selector: 'i.tech-icon.logo-mariadb',
   templateUrl: './mariadb.component.svg'
 })
 export class MariadbComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/max/max.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/max/max.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-max',
+  selector: 'i.tech-icon.logo-max',
   templateUrl: './max.component.svg',
   styleUrls: ['./max.component.scss']
 })

--- a/projects/angular-techs-logos/src/lib/techs/microsoft/microsoft.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/microsoft/microsoft.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-microsoft',
+  selector: 'i.tech-icon.logo-microsoft',
   templateUrl: './microsoft.component.svg'
 })
 export class MicrosoftComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/mint/mint.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/mint/mint.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-mint',
+  selector: 'i.tech-icon.logo-mint',
   templateUrl: './mint.component.svg',
   styleUrls: ['./mint.component.scss']
 })

--- a/projects/angular-techs-logos/src/lib/techs/mongodb/mongodb.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/mongodb/mongodb.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  selector: 'logo-mongodb',
+  selector: 'i.tech-icon.logo-mongodb',
   templateUrl: './mongodb.component.svg',
   styleUrls: ['./mongodb.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/angular-techs-logos/src/lib/techs/mozilla/mozilla.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/mozilla/mozilla.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-mozilla',
+  selector: 'i.tech-icon.logo-mozilla',
   templateUrl: './mozilla.component.svg',
 })
 export class MozillaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/mysql/mysql.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/mysql/mysql.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-mysql',
+  selector: 'i.tech-icon.logo-mysql',
   templateUrl: './mysql.component.svg'
 })
 export class MysqlComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/netflix/netflix.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/netflix/netflix.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-netflix',
+  selector: 'i.tech-icon.logo-netflix',
   templateUrl: './netflix.component.svg'
 })
 export class NetflixComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/nextjs/nextjs.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/nextjs/nextjs.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-nextjs',
+  selector: 'i.tech-icon.logo-nextjs',
   templateUrl: './nextjs.component.svg'
 })
 export class NextjsComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/nginx/nginx.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/nginx/nginx.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-nginx',
+  selector: 'i.tech-icon.logo-nginx',
   templateUrl: './nginx.component.svg'
 })
 export class NginxComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/node/node.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/node/node.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-node',
+  selector: 'i.tech-icon.logo-node',
   templateUrl: './node.component.svg'
 })
 export class NodeComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/npm/npm.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/npm/npm.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-npm',
+  selector: 'i.tech-icon.logo-npm',
   templateUrl: './npm.component.svg'
 })
 export class NpmComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/nuxt/nuxt.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/nuxt/nuxt.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-nuxt',
+  selector: 'i.tech-icon.logo-nuxt',
   templateUrl: './nuxt.component.svg'
 })
 export class NuxtComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/nvidia/nvidia.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/nvidia/nvidia.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-nvidia',
+  selector: 'i.tech-icon.logo-nvidia',
   templateUrl: './nvidia.component.svg'
 })
 export class NvidiaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/opensuse/opensuse.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/opensuse/opensuse.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-opensuse',
+  selector: 'i.tech-icon.logo-opensuse',
   templateUrl: './opensuse.component.svg'
 })
 export class OpensuseComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/opera/opera.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/opera/opera.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-opera',
+  selector: 'i.tech-icon.logo-opera',
   templateUrl: './opera.component.svg'
 })
 export class OperaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/oracle/oracle.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/oracle/oracle.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-oracle',
+  selector: 'i.tech-icon.logo-oracle',
   templateUrl: './oracle.component.svg'
 })
 export class OracleComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/pandas/pandas.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/pandas/pandas.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  selector: 'logo-pandas',
+  selector: 'i.tech-icon.logo-pandas',
   templateUrl: './pandas.component.svg',
   styleUrls: ['./pandas.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/projects/angular-techs-logos/src/lib/techs/php/php.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/php/php.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-php',
+  selector: 'i.tech-icon.logo-php',
   templateUrl: './php.component.svg'
 })
 export class PhpComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/pinterest/pinterest.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/pinterest/pinterest.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-pinterest',
+  selector: 'i.tech-icon.logo-pinterest',
   templateUrl: './pinterest.component.svg'
 })
 export class PinterestComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/playstore/playstore.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/playstore/playstore.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-playstore',
+  selector: 'i.tech-icon.logo-playstore',
   templateUrl: './playstore.component.svg'
 })
 export class PlaystoreComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/postgresql/postgresql.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/postgresql/postgresql.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-postgresql',
+  selector: 'i.tech-icon.logo-postgresql',
   templateUrl: './postgresql.component.svg'
 })
 export class PostgresqlComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/primevideo/primevideo.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/primevideo/primevideo.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-primevideo',
+  selector: 'i.tech-icon.logo-primevideo',
   templateUrl: './primevideo.component.svg'
 })
 export class PrimevideoComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/pwa/pwa.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/pwa/pwa.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-pwa',
+  selector: 'i.tech-icon.logo-pwa',
   templateUrl: './pwa.component.svg'
 })
 export class PwaComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/python/python.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/python/python.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-python',
+  selector: 'i.tech-icon.logo-python',
   templateUrl: './python.component.svg'
 })
 export class PythonComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/qwik/qwik.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/qwik/qwik.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-qwik',
+  selector: 'i.tech-icon.logo-qwik',
   templateUrl: './qwik.component.svg'
 })
 export class QwikComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/raspberry/raspberry.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/raspberry/raspberry.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-raspberry',
+  selector: 'i.tech-icon.logo-raspberry',
   templateUrl: './raspberry.component.svg'
 })
 export class RaspberryComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/react/react.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/react/react.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-react',
+  selector: 'i.tech-icon.logo-react',
   templateUrl: './react.component.svg'
 })
 export class ReactComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/redhat/redhat.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/redhat/redhat.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-redhat',
+  selector: 'i.tech-icon.logo-redhat',
   templateUrl: './redhat.component.svg'
 })
 export class RedhatComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/redis/redis.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/redis/redis.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-redis',
+  selector: 'i.tech-icon.logo-redis',
   templateUrl: './redis.component.svg'
 })
 export class RedisComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/ruby/ruby.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/ruby/ruby.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-ruby',
+  selector: 'i.tech-icon.logo-ruby',
   templateUrl: './ruby.component.svg'
 })
 export class RubyComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/rust/rust.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/rust/rust.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-rust',
+  selector: 'i.tech-icon.logo-rust',
   templateUrl: './rust.component.svg'
 })
 export class RustComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/safari/safari.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/safari/safari.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-safari',
+  selector: 'i.tech-icon.logo-safari',
   templateUrl: './safari.component.svg'
 })
 export class SafariComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/sass/sass.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/sass/sass.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-sass',
+  selector: 'i.tech-icon.logo-sass',
   templateUrl: './sass.component.svg'
 })
 export class SassComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/shopify/shopify.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/shopify/shopify.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-shopify',
+  selector: 'i.tech-icon.logo-shopify',
   templateUrl: './shopify.component.svg'
 })
 export class ShopifyComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/slackware/slackware.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/slackware/slackware.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-slackware',
+  selector: 'i.tech-icon.logo-slackware',
   templateUrl: './slackware.component.svg'
 })
 export class SlackwareComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/snapdragon/snapdragon.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/snapdragon/snapdragon.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-snapdragon',
+  selector: 'i.tech-icon.logo-snapdragon',
   templateUrl: './snapdragon.component.svg'
 })
 export class SnapdragonComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/soundcloud/soundcloud.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/soundcloud/soundcloud.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-soundcloud',
+  selector: 'i.tech-icon.logo-soundcloud',
   templateUrl: './soundcloud.component.svg'
 })
 export class SoundcloudComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/spacex/spacex.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/spacex/spacex.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-spacex',
+  selector: 'i.tech-icon.logo-spacex',
   templateUrl: './spacex.component.svg'
 })
 export class SpacexComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/spotify/spotify.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/spotify/spotify.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-spotify',
+  selector: 'i.tech-icon.logo-spotify',
   templateUrl: './spotify.component.svg'
 })
 export class SpotifyComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/springboot/springboot.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/springboot/springboot.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-springboot',
+  selector: 'i.tech-icon.logo-springboot',
   templateUrl: './springboot.component.svg'
 })
 export class SpringbootComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/stackoverflow/stackoverflow.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/stackoverflow/stackoverflow.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-stackoverflow',
+  selector: 'i.tech-icon.logo-stackoverflow',
   templateUrl: './stackoverflow.component.svg'
 })
 export class StackoverflowComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/steam/steam.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/steam/steam.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-steam',
+  selector: 'i.tech-icon.logo-steam',
   templateUrl: './steam.component.svg'
 })
 export class SteamComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/stylus/stylus.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/stylus/stylus.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-stylus',
+  selector: 'i.tech-icon.logo-stylus',
   templateUrl: './stylus.component.svg'
 })
 export class StylusComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/supabase/supabase.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/supabase/supabase.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-supabase',
+  selector: 'i.tech-icon.logo-supabase',
   templateUrl: './supabase.component.svg'
 })
 export class SupabaseComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/svelte/svelte.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/svelte/svelte.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-svelte',
+  selector: 'i.tech-icon.logo-svelte',
   templateUrl: './svelte.component.svg'
 })
 export class SvelteComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/swift/swift.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/swift/swift.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-swift',
+  selector: 'i.tech-icon.logo-swift',
   templateUrl: './swift.component.svg'
 })
 export class SwiftComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tailwind/tailwind.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tailwind/tailwind.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tailwind',
+  selector: 'i.tech-icon.logo-tailwind',
   templateUrl: './tailwind.component.svg'
 })
 export class TailwindComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/telegram/telegram.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/telegram/telegram.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-telegram',
+  selector: 'i.tech-icon.logo-telegram',
   templateUrl: './telegram.component.svg'
 })
 export class TelegramComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tensorflow/tensorflow.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tensorflow/tensorflow.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tensorflow',
+  selector: 'i.tech-icon.logo-tensorflow',
   templateUrl: './tensorflow.component.svg'
 })
 export class TensorflowComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tiktok/tiktok.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tiktok/tiktok.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tiktok',
+  selector: 'i.tech-icon.logo-tiktok',
   templateUrl: './tiktok.component.svg'
 })
 export class TiktokComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tomcat/tomcat.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tomcat/tomcat.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tomcat',
+  selector: 'i.tech-icon.logo-tomcat',
   templateUrl: './tomcat.component.svg'
 })
 export class TomcatComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tor/tor.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tor/tor.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tor',
+  selector: 'i.tech-icon.logo-tor',
   templateUrl: './tor.component.svg'
 })
 export class TorComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/torrent/torrent.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/torrent/torrent.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-torrent',
+  selector: 'i.tech-icon.logo-torrent',
   templateUrl: './torrent.component.svg'
 })
 export class TorrentComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/tumblr/tumblr.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/tumblr/tumblr.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-tumblr',
+  selector: 'i.tech-icon.logo-tumblr',
   templateUrl: './tumblr.component.svg'
 })
 export class TumblrComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/turbo/turbo.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/turbo/turbo.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-turbo',
+  selector: 'i.tech-icon.logo-turbo',
   templateUrl: './turbo.component.svg'
 })
 export class TurboComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/typescript/typescript.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/typescript/typescript.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-typescript',
+  selector: 'i.tech-icon.logo-typescript',
   templateUrl: './typescript.component.svg'
 })
 export class TypescriptComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/ubuntu/ubuntu.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/ubuntu/ubuntu.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-ubuntu',
+  selector: 'i.tech-icon.logo-ubuntu',
   templateUrl: './ubuntu.component.svg'
 })
 export class UbuntuComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/vercel/vercel.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/vercel/vercel.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-vercel',
+  selector: 'i.tech-icon.logo-vercel',
   templateUrl: './vercel.component.svg'
 })
 export class VercelComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/visualcode/visualcode.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/visualcode/visualcode.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-visualcode',
+  selector: 'i.tech-icon.logo-visualcode',
   templateUrl: './visualcode.component.svg'
 })
 export class VisualcodeComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/vite/vite.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/vite/vite.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-vite',
+  selector: 'i.tech-icon.logo-vite',
   templateUrl: './vite.component.svg'
 })
 export class ViteComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/vitest/vitest.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/vitest/vitest.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-vitest',
+  selector: 'i.tech-icon.logo-vitest',
   templateUrl: './vitest.component.svg'
 })
 export class VitestComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/vk/vk.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/vk/vk.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-vk',
+  selector: 'i.tech-icon.logo-vk',
   templateUrl: './vk.component.svg'
 })
 export class VkComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/vue/vue.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/vue/vue.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-vue',
+  selector: 'i.tech-icon.logo-vue',
   templateUrl: './vue.component.svg'
 })
 export class VueComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/webpack/webpack.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/webpack/webpack.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-webpack',
+  selector: 'i.tech-icon.logo-webpack',
   templateUrl: './webpack.component.svg'
 })
 export class WebpackComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/whatsapp/whatsapp.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/whatsapp/whatsapp.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-whatsapp',
+  selector: 'i.tech-icon.logo-whatsapp',
   templateUrl: './whatsapp.component.svg'
 })
 export class WhatsappComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/wordpress/wordpress.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/wordpress/wordpress.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-wordpress',
+  selector: 'i.tech-icon.logo-wordpress',
   templateUrl: './wordpress.component.svg'
 })
 export class WordpressComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/x/x.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/x/x.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-x',
+  selector: 'i.tech-icon.logo-x',
   templateUrl: './x.component.svg'
 })
 export class XComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/xcode/xcode.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/xcode/xcode.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-xcode',
+  selector: 'i.tech-icon.logo-xcode',
   templateUrl: './xcode.component.svg'
 })
 export class XcodeComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/yandex/yandex.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/yandex/yandex.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-yandex',
+  selector: 'i.tech-icon.logo-yandex',
   templateUrl: './yandex.component.svg'
 })
 export class YandexComponent {}

--- a/projects/angular-techs-logos/src/lib/techs/youtube/youtube.component.ts
+++ b/projects/angular-techs-logos/src/lib/techs/youtube/youtube.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'logo-youtube',
+  selector: 'i.tech-icon.logo-youtube',
   templateUrl: './youtube.component.svg',
 })
 export class YoutubeComponent {}

--- a/src/app/list-techs/list-techs.component.ts
+++ b/src/app/list-techs/list-techs.component.ts
@@ -1,6 +1,6 @@
 import { Component, effect, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AngularTechsLogosModule, Tech, techs } from 'angular-techs-logos';
+import { AngularTechsLogosModule, Tech, techs } from '../../../projects/angular-techs-logos/src/public-api';
 
 @Component({
   selector: 'list-techs',


### PR DESCRIPTION
This pull request introduces a new `raw` input to the Tech Icons component, allowing developers to display only the raw SVG logo without additional HTML elements like `figure` or `figcaption`. The raw mode offers greater flexibility in rendering logos without surrounding containers, making it easier to embed the icons in different layouts.

### Changes:
- **Add `raw` Input**: The component now accepts a boolean `raw` input to toggle between rendering the full structure with captions or just the raw SVG.
- **Template Adjustments**: The template has been modified to conditionally render either the raw SVG or the full structure depending on the value of the `raw` input.
- **Style Adjustments**: Minor style adjustments were made to ensure proper rendering of the tech icons in both raw and standard modes.
- **Selector Updates**: Selectors have been updated with the `tech-icon` class to ensure consistency in applying styles and behavior.

### Testing:
- Unit tests were added to ensure that the component correctly renders the raw SVGs when the `raw` input is set to true.
- All existing functionality was verified to remain unaffected when `raw` is not used.