### PR TITLE
Implement Persistent State Control for `showRaw` and `hiddenLabel` Checkboxes

### DIFF
--- a/src/app/list-techs/list-techs.component.html
+++ b/src/app/list-techs/list-techs.component.html
@@ -1,29 +1,54 @@
 <nucleus-box title="List of techs">
-  <input
-    class="input-search"
-    type="text"
-    [(ngModel)]="searchSignal"
-    placeholder="Search logo name..."
-    (input)="onSearchChange($event)"
-  />
-  <angular-techs-logos [list]="techsFiltered" />
-  @if (techsFiltered.length == 0) {
-    <div class="not-found">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        width="100px"
-        height="100px"
-        viewBox="-20 0 190 190"
-      >
-        <path
-          fill="var(--vtl-background-svg)"
-          fill-rule="evenodd"
-          d="m38.155 140.475 10.833-78.364 43.881 4.946 18.568 23.955-8.041 57.109-65.241-7.646Zm45.858-46.473 4.814-22.195-34.781-3.5-9.854 67.15 54.143 6.627 6.542-45.275-20.864-2.807Zm-24.242 29.593c-.377-.496-3.721-3.296-4.35-4.162 8.899-9.911 30.629-9.788 36.664 3.324-1.005.371-5.495 2.315-6.375 2.81-2.518-7.317-17.265-9.625-25.939-1.972Zm16.732-27.096-3.666 2.76-5.515-6.642-7.507 4.03-3.029-5.07 6.829-3.426-4.526-5.452 5.5-3.68 4.39 6.439 7.819-3.925 2.356 4.73-7.047 3.784 4.396 6.452Z"
-          clip-rule="evenodd"
+  <div class="inputs-actions">
+    <input
+      class="input-search"
+      type="text"
+      [(ngModel)]="searchSignal"
+      placeholder="Search logo name..."
+      (input)="onSearchChange($event)"
+    />
+    <div class="checkbox-container">
+      <label>
+        <input
+          type="checkbox"
+          [(ngModel)]="showRaw"
+          (change)="onCheckboxChange('showRaw')"
         />
-      </svg>
-      <p>No logos found matching your search.</p>
+        Show Raw
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          [(ngModel)]="hiddenLabel"
+          (change)="onCheckboxChange('hiddenLabel')"
+        />
+        Hidden Label
+      </label>
     </div>
+  </div>
+
+  <angular-techs-logos
+    [list]="techsFiltered"
+    [raw]="showRaw"
+    [hiddenLabel]="hiddenLabel"
+  />
+  @if (techsFiltered.length == 0) {
+  <div class="not-found">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      width="100px"
+      height="100px"
+      viewBox="-20 0 190 190"
+    >
+      <path
+        fill="var(--vtl-background-svg)"
+        fill-rule="evenodd"
+        d="m38.155 140.475 10.833-78.364 43.881 4.946 18.568 23.955-8.041 57.109-65.241-7.646Zm45.858-46.473 4.814-22.195-34.781-3.5-9.854 67.15 54.143 6.627 6.542-45.275-20.864-2.807Zm-24.242 29.593c-.377-.496-3.721-3.296-4.35-4.162 8.899-9.911 30.629-9.788 36.664 3.324-1.005.371-5.495 2.315-6.375 2.81-2.518-7.317-17.265-9.625-25.939-1.972Zm16.732-27.096-3.666 2.76-5.515-6.642-7.507 4.03-3.029-5.07 6.829-3.426-4.526-5.452 5.5-3.68 4.39 6.439 7.819-3.925 2.356 4.73-7.047 3.784 4.396 6.452Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    <p>No logos found matching your search.</p>
+  </div>
   }
 </nucleus-box>

--- a/src/app/list-techs/list-techs.component.scss
+++ b/src/app/list-techs/list-techs.component.scss
@@ -6,7 +6,22 @@
   background: var(--vtl-background);
   border: 2px solid var(--vtl-background);
   color: var(--color-text);
-  width: 100%;
+  width: calc(100% - 190px);
+}
+
+.inputs-actions {
+  display: flex;
+  gap: 20px;
+}
+.checkbox-container {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  height: 80px;
+  label input {
+    margin-right: 1rem;
+  }
 }
 
 .not-found {

--- a/src/app/list-techs/list-techs.component.ts
+++ b/src/app/list-techs/list-techs.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, signal } from '@angular/core';
+import { Component, effect, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NucleusBox } from 'nucleus-angular';
 import {
@@ -14,10 +14,27 @@ import {
   templateUrl: './list-techs.component.html',
   styleUrl: './list-techs.component.scss',
 })
-export class ListTechsComponent {
+export class ListTechsComponent implements OnInit {
   techs: Tech[] = techs;
   techsFiltered: string[] = [];
+  showRaw: boolean = false;
+  hiddenLabel: boolean = false;
   searchSignal = signal<string>('');
+
+  ngOnInit() {
+    this.showRaw = JSON.parse(localStorage.getItem('showRaw') || 'false');
+    this.hiddenLabel = JSON.parse(
+      localStorage.getItem('hiddenLabel') || 'false'
+    );
+  }
+
+  private getProperty(key: 'showRaw' | 'hiddenLabel'): boolean {
+    return this[key];
+  }
+
+  onCheckboxChange(key: 'showRaw' | 'hiddenLabel') {
+    localStorage.setItem(key, JSON.stringify(this.getProperty(key)));
+  }
 
   techsFilteredEffect = effect(() => {
     this.techsFiltered = this.techs


### PR DESCRIPTION
This PR adds persistent state management for `showRaw` and `hiddenLabel` checkboxes in the `ListTechsComponent`. Using `localStorage`, this implementation retains the checkbox selections across sessions, ensuring a consistent user experience.

#### Changes Made
1. **Component State Initialization**:
   - Added `showRaw` and `hiddenLabel` properties to the `ListTechsComponent`.
   - Initialized these properties in `ngOnInit`, retrieving any existing values from `localStorage`.

2. **Checkbox Template Update**:
   - Created two checkboxes in the `list-techs.component.html` template, using `[(ngModel)]` for two-way binding to `showRaw` and `hiddenLabel`.

3. **Persistent Storage on Change**:
   - Added an `onCheckboxChange` method that updates `localStorage` whenever a checkbox is toggled.
   - Ensured TypeScript type safety by limiting `key` to `'showRaw'` or `'hiddenLabel'` and using a helper method to access the properties dynamically.